### PR TITLE
Add unit tests for move and evaluate

### DIFF
--- a/.github/workflows/python-suite.yml
+++ b/.github/workflows/python-suite.yml
@@ -27,7 +27,7 @@ jobs:
         pip install -e .
     - name: Run Unit Tests
       run: |
-        pytest .
+        pytest . -vv
     - name: Check with black
       run: |
         black . --check

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -1,0 +1,19 @@
+import chess
+
+from chess_ai import evaluate
+
+
+def test_evaluate_board():
+    b = chess.Board()
+    value = evaluate.evaluate_board(b)
+    assert 0 == value
+
+    b = chess.Board("4kr2/4b3/8/2p1R2p/4n1p1/3q2P1/7P/4K3 w - - 4 38")
+    value = evaluate.evaluate_board(b)
+    assert -16 == value
+    value = evaluate.evaluate_board(b, chess.Move.from_uci("e5h5"))
+    assert -15 == value
+
+    b = chess.Board("4kr2/4b3/8/2p1R2p/4n1p1/3q2P1/7P/8")
+    value = evaluate.evaluate_board(b)
+    assert -916 == value

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -7,3 +7,44 @@ def test_next_move():
     b = chess.Board()
     best_move = move.next_move(1, b)
     assert "a2a4" == best_move.uci()
+
+
+def test_get_ordered_moves():
+    b = chess.Board("4kr2/4b3/8/2p1R2p/4n1p1/3q2P1/7P/4K3 w - - 4 38")
+    actual_ordered_moves = move.get_ordered_moves(b)
+    expected_ordered_moves = [
+        "e5e7",
+        "e5e4",
+        "e5h5",
+        "e5c5",
+        "e5e6",
+        "e5g5",
+        "e5f5",
+        "e5d5",
+        "h2h3",
+        "h2h4",
+    ]
+
+    assert len(expected_ordered_moves) == len(actual_ordered_moves)
+
+    for i in range(len(expected_ordered_moves)):
+        assert expected_ordered_moves[i] == actual_ordered_moves[i].uci()
+
+
+def test_minimax_root():
+    b = chess.Board()
+    best_move = move.minimax_root(1, b)
+    assert "a2a4" == best_move.uci()
+
+    b = chess.Board("4kr2/4b3/8/2p1R2p/4n1p1/3q2P1/7P/4K3 w - - 4 38")
+    best_move = move.minimax_root(2, b)
+    assert "e5h5" == best_move.uci()
+
+
+def test_minimax():
+    b = chess.Board("4kr2/4b3/8/2p1R2p/4n1p1/3q2P1/7P/4K3 w - - 4 38")
+    best_value = move.minimax(1, b, True)
+    assert -13 == best_value
+
+    best_value = move.minimax(3, b, True)
+    assert -18 == best_value


### PR DESCRIPTION
Will omit writing tests for any other parts of the project for the time being. Benchmarking is much more important and given that the project will likely change in the near future, writing unit tests now seems like a waste of time.

The tests are inside of `tests/` and can be executed with `pytest .`.