### PR TITLE
Fix evaluation function and add better unit tests

### DIFF
--- a/src/chess_ai/evaluate.py
+++ b/src/chess_ai/evaluate.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 
+INF = 99999
+
 mg_pawn_table = np.array(
     [
         [0, 0, 0, 0, 0, 0, 0, 0],
@@ -166,12 +168,12 @@ mg_total_table = np.stack(
         mg_rook_table,
         mg_queen_table,
         mg_king_table,
-        np.flipud(mg_pawn_table),
-        np.flipud(mg_knight_table),
-        np.flipud(mg_bishop_table),
-        np.flipud(mg_rook_table),
-        np.flipud(mg_queen_table),
-        np.flipud(mg_king_table),
+        np.flipud(mg_pawn_table) * -1,
+        np.flipud(mg_knight_table) * -1,
+        np.flipud(mg_bishop_table) * -1,
+        np.flipud(mg_rook_table) * -1,
+        np.flipud(mg_queen_table) * -1,
+        np.flipud(mg_king_table) * -1,
     )
 )
 mg_piece_values_table = np.vstack(
@@ -185,6 +187,9 @@ piece_values = [1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6]
 
 
 def evaluate_board(board, move=None):
+    if board.checkmate:
+        return -INF if board.white_to_move else INF
+
     start_B = board.to_np()
 
     if move:
@@ -204,5 +209,8 @@ def evaluate_board(board, move=None):
 
     eval_sum = np.sum(mg_total_table[mask])
     eval_sum += np.sum(mg_piece_values_table[mask])
+
+    if board.stalemate:
+        return -eval_sum
 
     return eval_sum

--- a/tests/boards_and_evaluations.csv
+++ b/tests/boards_and_evaluations.csv
@@ -1,0 +1,5 @@
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1,0
+r1b4k/p5p1/4pq2/1p1p4/2n2P2/P2B4/1P2Q2P/1K1R3R b - - 1 24,+100
+6r1/8/p1k5/2p1nbB1/PpPp4/1P1P4/1K2N3/6R1 w - - 0 1,-50
+6r1/P7/K1k5/2p5/1pPp4/1P1P4/8/4R3 w - - 0 1,+200
+Q7/8/K7/2p1k3/1pPp4/1P1P4/8/8 w - - 0 1,-INF

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -1,13 +1,11 @@
+import os
+
 import chess_ai.chess_engine as chess
 from chess_ai.evaluate import evaluate_board
+from chess_ai.evaluate import INF
 
 
-def test_evaluate_board():
-    """
-    This test is not to check that the output works,
-    but rather to test if the function changes the given
-    board in a way we don't want it to.
-    """
+def test_board_change():
     start_fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
     board = chess.Board(start_fen)
 
@@ -41,3 +39,87 @@ def test_evaluate_board():
     for i in range(depth):
         board.undo_move()
     assert start_fen == board.fen()
+
+
+def test_evaluation():
+    error_range = 50
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(script_dir, "boards_and_evaluations.csv"), "r") as f:
+        data = f.readlines()
+
+    for data_row in data:
+        data_row = data_row.rstrip()
+        fen, expected_value = data_row.split(",")
+        if expected_value == "INF":
+            expected_value = INF
+        elif expected_value == "-INF":
+            expected_value = -INF
+        else:
+            expected_value = int(expected_value)
+
+        board = chess.Board(fen)
+        actual_value = evaluate_board(board)
+
+        err_msg = """
+Expected value: {}
+Actual Value: {}
+Error Range: {}
+Fen string: {}
+        """.format(
+            expected_value, actual_value, error_range, fen
+        )
+
+        assert abs(expected_value - actual_value) <= error_range, err_msg
+
+
+def test_castling_evaluation():
+    pre_castling_board = chess.Board(
+        "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/3P1N2/PPP2PPP/RNBQK2R w KQkq - 1 5"
+    )
+    post_castling_board = chess.Board(
+        "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/3P1N2/PPP2PPP/RNBQ1RK1 b kq - 2 5"
+    )
+
+    assert evaluate_board(pre_castling_board) < evaluate_board(post_castling_board)
+
+
+def test_checkmate_evaluation():
+    checkmate_board = chess.Board(
+        "r1bqk1nr/pppp1Qpp/2n5/2b1p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4"
+    )
+    assert checkmate_board.checkmate
+    assert INF == evaluate_board(checkmate_board)
+
+    checkmate_board = chess.Board("1k6/1Q6/1K6/2p5/1pPp4/1P1P4/8/8 b - - 15 8")
+    assert checkmate_board.checkmate
+    assert INF == evaluate_board(checkmate_board)
+
+    checkmate_board = chess.Board(
+        "rnb1k1nr/pppp1ppp/8/2b1p3/2B1P3/2N5/PPPP1qPP/R1BQK1NR w KQkq - 0 1"
+    )
+    assert checkmate_board.checkmate
+    assert -INF == evaluate_board(checkmate_board)
+
+
+def test_stalemate_evaluation():
+    stalemate_board = chess.Board("1k6/1P6/1K6/8/8/8/8/8 b - - 0 1")
+    assert stalemate_board.stalemate
+    assert -50 > evaluate_board(stalemate_board)
+
+    stalemate_board = chess.Board("8/8/8/5k2/5p2/5K2/r7/8 w - - 0 1")
+    assert stalemate_board.stalemate
+    assert 50 < evaluate_board(stalemate_board)
+
+
+def test_king_of_the_hill_evaluation():
+    checkmate_board = chess.Board("5r2/8/2p3p1/3kp2p/8/P2P4/1PP5/2KR4 w - - 0 1")
+    assert checkmate_board.checkmate
+    assert -INF == evaluate_board(checkmate_board)
+
+    checkmate_board = chess.Board("8/8/8/4k3/5p2/5K2/r7/8 w - - 0 1")
+    assert checkmate_board.checkmate
+    assert -INF == evaluate_board(checkmate_board)
+
+    checkmate_board = chess.Board("3r4/2k5/2p5/8/4K3/8/8/8 b - - 0 1")
+    assert checkmate_board.checkmate
+    assert INF == evaluate_board(checkmate_board)


### PR DESCRIPTION
The tables for black and white were not equal, the starting position didn't give an evaluation of 0. Apart from fixing that, this commit also added checks for `checkmate` and `stalemate` and sets the evaluation value accordingly.

Also added better unit tests for the evaluation function.

Closes #42.