### PR TITLE
Add transposition tables with zobrist hashing

### DIFF
--- a/.github/workflows/python-suite.yml
+++ b/.github/workflows/python-suite.yml
@@ -16,6 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install C build tools
+      run: |
+        sudo apt-get update && sudo apt-get install -y build-essential
+    - name: Compile C library
+      run: |
+        gcc -shared -fPIC src/chess_ai/transposition_tables.c -o src/chess_ai/transposition_tables.so
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -86,7 +86,7 @@ def bench_move(board, move):
 def bench_evaluate(board, move=None):
     with contextlib.redirect_stdout(suppress_prints()):
         with contextlib.redirect_stderr(suppress_prints()):
-            evaluate.evaluate_board(board, move)
+            evaluate.evaluate_board(board, move, use_table=False)
 
 
 def bench_best_move(depth, board, debug_info):

--- a/src/chess_ai/evaluate.py
+++ b/src/chess_ai/evaluate.py
@@ -4,6 +4,9 @@ import numpy as np
 import cffi
 
 
+INF = 99999
+EMPTY_SCORE = 42069
+
 ffi = cffi.FFI()
 
 ffi.cdef(
@@ -14,20 +17,18 @@ typedef struct {
 } TranspositionEntry;
 """
 )
-ffi.cdef("void init_zobrist_keys();")
+ffi.cdef("void init();")
 ffi.cdef("TranspositionEntry get_table(int (*board)[8]);")
 ffi.cdef("void set_table(uint64_t hash, int score);")
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 transposition_lib = ffi.dlopen(os.path.join(script_dir, "transposition_tables.so"))
 
-transposition_lib.init_zobrist_keys()
+transposition_lib.init()
 
 # transposition_lib.get_table.argtypes = [ffi.typeof("int[64]")]
 # transposition_lib.get_table.restype = ffi.typeof("TranspositionEntry")
 
-INF = 99999
-EMPTY_SCORE = 42069
 
 mg_pawn_table = np.array(
     [
@@ -240,6 +241,7 @@ def evaluate_board(board, move=None, use_table=True):
     transposition_entry = transposition_lib.get_table(data_ptr)
 
     if use_table and transposition_entry.score != EMPTY_SCORE:
+        raise ValueError(transposition_entry.score)
         # TODO Add debug info transpositions
         return transposition_entry.score
 

--- a/src/chess_ai/transposition_tables.c
+++ b/src/chess_ai/transposition_tables.c
@@ -1,0 +1,65 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#define TABLE_ENTRIES 1000000
+#define EMPTY_SCORE 42069
+
+uint64_t zobrist_keys[8][8][12];
+
+typedef struct {
+    uint64_t hash;
+    int score;
+    // Other fields as needed
+} TranspositionEntry;
+TranspositionEntry table[TABLE_ENTRIES];
+
+void init_zobrist_keys() {
+    for (int i = 0; i < 8; ++i) {
+        for (int j = 0; j < 8; ++j) {
+            for (int piece = 0; piece < 12; ++piece) {
+                zobrist_keys[i][j][piece] = ((uint64_t)rand() << 32) | rand();
+            }
+        }
+    }
+}
+
+uint64_t get_piece_index(int piece_value) {
+    if (piece_value >= 0) {
+        return piece_value;
+    } else {
+        return 6 - piece_value;
+    }
+}
+
+void set_table(uint64_t hash, int score) {
+    int index = hash % TABLE_ENTRIES;
+    table[index].hash = hash;
+    table[index].score = score;
+    // Other fields can be updated as needed
+}
+
+uint64_t get_hash(int (*board)[8]) {
+    uint64_t hash = 0;
+    for (int i = 0; i < 8; ++i) {
+        for (size_t j = 0; j < 8; j++) {
+            int piece = get_piece_index(board[i][j]);
+            if (piece != 0) {
+                hash ^= zobrist_keys[i][j][piece];
+            }
+        }
+    }
+    return hash;
+}
+
+TranspositionEntry get_table(int (*board)[8]) {
+    uint64_t hash = get_hash(board);
+    int index = hash % TABLE_ENTRIES;
+    TranspositionEntry entry = table[index];
+    if (entry.hash == hash) {
+        return entry;
+    }
+    set_table(hash, EMPTY_SCORE);
+    return entry;
+}

--- a/src/chess_ai/transposition_tables.c
+++ b/src/chess_ai/transposition_tables.c
@@ -25,6 +25,17 @@ void init_zobrist_keys() {
     }
 }
 
+void init_table() {
+    for (size_t i = 0; i < TABLE_ENTRIES; i++) {
+        table[i].score = EMPTY_SCORE;
+    }
+}
+
+void init() {
+    init_zobrist_keys();
+    init_table();
+}
+
 uint64_t get_piece_index(int piece_value) {
     if (piece_value >= 0) {
         return piece_value;
@@ -57,9 +68,5 @@ TranspositionEntry get_table(int (*board)[8]) {
     uint64_t hash = get_hash(board);
     int index = hash % TABLE_ENTRIES;
     TranspositionEntry entry = table[index];
-    if (entry.hash == hash) {
-        return entry;
-    }
-    set_table(hash, EMPTY_SCORE);
     return entry;
 }


### PR DESCRIPTION
The transposition tables use zobrist hashing. The addition of this increases the time for each evaluation to around 10 microseconds (from 45 -> 55). This is pretty much unavoidable, however it would be possible to reduce 5 microseconds if we would use C for the whole evaluation function. This would also reduce the total time (I would guess by around 20 microseconds, definitely not any more then that).